### PR TITLE
Support for Commands in Module Groups and Help for Alias Commands

### DIFF
--- a/src/CommandServiceExtension.cs
+++ b/src/CommandServiceExtension.cs
@@ -23,7 +23,7 @@ namespace Discord.Addons.CommandsExtension
         {
             EmbedBuilder helpEmbedBuilder;
             var commandModules = commandService.GetModulesWithCommands();
-            var moduleMatch = commandModules.FirstOrDefault(m => m.Name == command);
+            var moduleMatch = commandModules.FirstOrDefault(m => m.Name == command || m.Aliases.Contains(command));
 
             if (string.IsNullOrEmpty(command))
             {
@@ -61,17 +61,23 @@ namespace Discord.Addons.CommandsExtension
             var helpEmbedBuilder = new EmbedBuilder();
             var commandSearchResult = commandService.Search(command);
 
-            
-            var commandModulesList = commandService.Modules.ToList();
             var commandsInfoWeNeed = new List<CommandInfo>();
-            foreach (var c in commandModulesList) commandsInfoWeNeed.AddRange(c.Commands.Where(h => string.Equals(h.Name, command, StringComparison.CurrentCultureIgnoreCase)));
 
+            if (commandSearchResult.IsSuccess)
+            {
+                foreach (var c in commandSearchResult.Commands) commandsInfoWeNeed.Add(c.Command);
+            }
+            else
+            {
+                var commandModulesList = commandService.Modules.ToList();
+                foreach (var c in commandModulesList) commandsInfoWeNeed.AddRange(c.Commands.Where(h => string.Equals(h.Name, command, StringComparison.CurrentCultureIgnoreCase)));
+            }
 
             if(pageNum > commandsInfoWeNeed.Count  || pageNum <=0)
                 pageNum = 1;
 
 
-            if (!commandSearchResult.IsSuccess || commandsInfoWeNeed.Count <= 0)
+            if (commandsInfoWeNeed.Count <= 0)
             {
                 helpEmbedBuilder.WithTitle("Command not found");
                 return helpEmbedBuilder;

--- a/src/CommandServiceExtension.cs
+++ b/src/CommandServiceExtension.cs
@@ -10,7 +10,7 @@ namespace Discord.Addons.CommandsExtension
     {
         public static CommandServiceInfo GetCommandServiceInfo(this CommandService commandService, string command)
         {
-    
+
             var commandInfo = commandService.Search(command).Commands.FirstOrDefault().Command;
             var module = commandInfo.Module;
             var aliases = string.Join(", ", commandInfo.Aliases);
@@ -51,6 +51,7 @@ namespace Discord.Addons.CommandsExtension
         private static EmbedBuilder GenerateSpecificCommandHelpEmbed(this CommandService commandService, string command, string prefix)
         {
 
+            //TODO: This won't allow commands that ends with a number
             var isNumeric = int.TryParse(command[command.Length - 1].ToString(), out var pageNum);
 
             if (isNumeric)
@@ -73,7 +74,7 @@ namespace Discord.Addons.CommandsExtension
                 foreach (var c in commandModulesList) commandsInfoWeNeed.AddRange(c.Commands.Where(h => string.Equals(h.Name, command, StringComparison.CurrentCultureIgnoreCase)));
             }
 
-            if(pageNum > commandsInfoWeNeed.Count  || pageNum <=0)
+            if (pageNum > commandsInfoWeNeed.Count || pageNum <= 0)
                 pageNum = 1;
 
 

--- a/src/CommandsExtension.cs
+++ b/src/CommandsExtension.cs
@@ -10,7 +10,7 @@ namespace Discord.Addons.CommandsExtension
     {
         public static string GetModuleInfo(this ModuleInfo module)
         {
-            var moduleCommands = string.Join(", ", module.Commands.Select(c => c.GetCommandNameWithGroup()));
+            var moduleCommands = string.Join(", ", module.Commands.Select(c => c.MainName()));
             var sb = new StringBuilder()
                 .AppendLine(moduleCommands);
             return sb.ToString();
@@ -37,7 +37,7 @@ namespace Discord.Addons.CommandsExtension
             var aliases = string.Join(", ", command.Aliases);
             var module = command.Module.Name;
             var parameters = string.Join(", ", command.GetCommandParameters());
-            var name = command.GetCommandNameWithGroup();
+            var name = command.MainName();
             var summary = command.Summary;
             var sb = new StringBuilder()
                 .AppendLine($"**Command name**: {name}")
@@ -59,7 +59,7 @@ namespace Discord.Addons.CommandsExtension
             var optionalTemplate = "<{0}>";
             var mandatoryTemplate = "[{0}]";
             List<string> parametersFormated = new List<string>();
-            
+
             foreach (var parameter in parameters)
             {
                 if (parameter.IsOptional)
@@ -74,10 +74,20 @@ namespace Discord.Addons.CommandsExtension
         /// <summary>
         /// Returns the command name with the group name attached.
         /// If there is no group, will return the command name.
+        /// Warning: if there is a NameAttribute in the command, its will be returned instead of the command name,
+        /// it's not warranteed to be an executable name
         /// </summary>
+        [Obsolete("Deprecated. Use MainName instead.")]
         public static string GetCommandNameWithGroup(this CommandInfo commandInfo)
         {
             return commandInfo.Module.Group != null ? $"{commandInfo.Module.Group} {commandInfo.Name}" : commandInfo.Name;
         }
+
+        /// <summary>
+        /// Returns the main command name used to execute this command.
+        /// If the command is in a module with a GroupAttribute, the group name will be included in the command name.
+        /// If there is an AliasAttribute defined before the CommandAttribute, the first alias will be used
+        /// </summary>
+        public static string MainName(this CommandInfo commandInfo) => commandInfo.Aliases.First();
     }
 }


### PR DESCRIPTION
fixes #5 and helps in getting Help for Aliases of Commands and Module Groups.
What still does not work is finding Commands in Groups by Name if the name is not an Alias for the Command.
But if the Name is set like that, the default Help Embed does not make very much sense anyway because the usage always uses the name and not the first Alias (e.g. Command is `<blah`, but the name is blubb, usage would say `<blubb` and that is no valid command).